### PR TITLE
Rename package-data entry to ccdtools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 [tool.setuptools.package-data]
-datapool = ["config/*.yml", "config/*.yaml"]
+ccdtools = ["config/*.yml", "config/*.yaml"]
 
 [project.urls]
 Homepage = "https://github.com/ACCESS-NRI/ccdtools"


### PR DESCRIPTION
Fix pyproject.toml package-data key from `datapool` to `ccdtools` so config/*.yml and config/*.yaml are associated with the correct package. Ensures these config files are included in built distributions for the ccdtools package.

Fixes #45 